### PR TITLE
bulk_upsert operates on models rather than dictionaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Performs an update on an object or an insert if the object does not exist.
     print model_obj.int_field, model_obj.float_field
     2, 4.0
 
-## bulk_upsert(objs, unique_fields, update_fields)<a name="bulk_upsert"></a>
-Performs a bulk update or insert on a list of dictionaries. Matches all objects in the queryset with the objs provided using the field values in unique_fields. If an existing object is matched, it is updated with the values from the provided objects. Objects that don't match anything are bulk inserted.
+## bulk_upsert(model_objs, unique_fields, update_fields)<a name="bulk_upsert"></a>
+Performs a bulk update or insert on a list of model objects. Matches all objects in the queryset with the objs provided using the field values in unique_fields. If an existing object is matched, it is updated with the values from the provided objects. Objects that don't match anything are bulk inserted.
 
 **Args**:
 - objs: A list of dictionaries that have fields corresponding to the model in the manager.
@@ -118,9 +118,9 @@ Performs a bulk update or insert on a list of dictionaries. Matches all objects 
     # Start off with no objects in the database. Call a bulk_upsert on the TestModel, which includes
     # a char_field, int_field, and float_field
     TestModel.objects.bulk_upsert([
-        {'float_field': 1.0, 'char_field': '1', 'int_field': 1},
-        {'float_field': 2.0, 'char_field': '2', 'int_field': 2},
-        {'float_field': 3.0, 'char_field': '3', 'int_field': 3},
+        TestModel(float_field=1.0, char_field='1', int_field=1),
+        TestModel(float_field=2.0, char_field='2', int_field=2),
+        TestModel(float_field=3.0, char_field='3', int_field=3),
     ], ['int_field'], ['char_field'])
 
     # All objects should have been created
@@ -130,9 +130,9 @@ Performs a bulk update or insert on a list of dictionaries. Matches all objects 
     # Now perform a bulk upsert on all the char_field values. Since the objects existed previously
     # (known by the int_field uniqueness constraint), the char fields should be updated
     TestModel.objects.bulk_upsert([
-        {'float_field': 1.0, 'char_field': '0', 'int_field': 1},
-        {'float_field': 2.0, 'char_field': '0', 'int_field': 2},
-        {'float_field': 3.0, 'char_field': '0', 'int_field': 3},
+        TestModel(float_field=1.0, char_field='0', int_field=1),
+        TestModel(float_field=2.0, char_field='0', int_field=2),
+        TestModel(float_field=3.0, char_field='0', int_field=3),
     ], ['int_field'], ['char_field'])
 
     # No more new objects should have been created, and every char field should be 0
@@ -142,10 +142,10 @@ Performs a bulk update or insert on a list of dictionaries. Matches all objects 
     # Do the exact same operation, but this time add an additional object that is not already
     # stored. It will be inserted.
     TestModel.objects.bulk_upsert([
-        {'float_field': 1.0, 'char_field': '1', 'int_field': 1},
-        {'float_field': 2.0, 'char_field': '2', 'int_field': 2},
-        {'float_field': 3.0, 'char_field': '3', 'int_field': 3},
-        {'float_field': 4.0, 'char_field': '4', 'int_field': 4},
+        TestModel(float_field=1.0, char_field='1', int_field=1),
+        TestModel(float_field=2.0, char_field='2', int_field=2),
+        TestModel(float_field=3.0, char_field='3', int_field=3),
+        TestModel(float_field=4.0, char_field='4', int_field=4),
     ], ['int_field'], ['char_field'])
 
     # There should be one more object
@@ -156,10 +156,10 @@ Performs a bulk update or insert on a list of dictionaries. Matches all objects 
     # filter for int_field=1. In this case, only one object has the ability to be updated.
     # All of the other objects will be inserted
     TestModel.objects.filter(int_field=1).bulk_upsert([
-        {'float_field': 1.0, 'char_field': '1', 'int_field': 1},
-        {'float_field': 2.0, 'char_field': '2', 'int_field': 2},
-        {'float_field': 3.0, 'char_field': '3', 'int_field': 3},
-        {'float_field': 4.0, 'char_field': '4', 'int_field': 4},
+        TestModel(float_field=1.0, char_field='1', int_field=1),
+        TestModel(float_field=2.0, char_field='2', int_field=2),
+        TestModel(float_field=3.0, char_field='3', int_field=3),
+        TestModel(float_field=4.0, char_field='4', int_field=4),
     ], ['int_field'], ['char_field'])
 
     # There should be three more objects

--- a/test_project/tests/manager_utils_tests.py
+++ b/test_project/tests/manager_utils_tests.py
@@ -37,9 +37,9 @@ class BulkUpsertTest(TestCase):
         Tests the case when no updates were previously stored (i.e objects are only created)
         """
         TestModel.objects.bulk_upsert([
-            {'int_field': 0, 'char_field': '0', 'float_field': 0},
-            {'int_field': 1, 'char_field': '1', 'float_field': 1},
-            {'int_field': 2, 'char_field': '2', 'float_field': 2},
+            TestModel(int_field=0, char_field='0', float_field=0),
+            TestModel(int_field=1, char_field='1', float_field=1),
+            TestModel(int_field=2, char_field='2', float_field=2),
         ], ['int_field'], ['char_field', 'float_field'])
 
         for i, model_obj in enumerate(TestModel.objects.order_by('int_field')):
@@ -58,9 +58,9 @@ class BulkUpsertTest(TestCase):
 
         # Update using the int field as a uniqueness constraint
         TestModel.objects.bulk_upsert([
-            {'int_field': 0, 'char_field': '0', 'float_field': 0},
-            {'int_field': 1, 'char_field': '1', 'float_field': 1},
-            {'int_field': 2, 'char_field': '2', 'float_field': 2},
+            TestModel(int_field=0, char_field='0', float_field=0),
+            TestModel(int_field=1, char_field='1', float_field=1),
+            TestModel(int_field=2, char_field='2', float_field=2),
         ], ['int_field'], ['char_field', 'float_field'])
 
         # Verify that the fields were updated
@@ -81,9 +81,9 @@ class BulkUpsertTest(TestCase):
 
         # Update using the int field as a uniqueness constraint
         TestModel.objects.bulk_upsert([
-            {'int_field': 0, 'char_field': '0', 'float_field': 0},
-            {'int_field': 1, 'char_field': '1', 'float_field': 1},
-            {'int_field': 2, 'char_field': '2', 'float_field': 2},
+            TestModel(int_field=0, char_field='0', float_field=0),
+            TestModel(int_field=1, char_field='1', float_field=1),
+            TestModel(int_field=2, char_field='2', float_field=2),
         ], ['int_field'], update_fields=['float_field'])
 
         # Verify that the float field was updated
@@ -104,9 +104,9 @@ class BulkUpsertTest(TestCase):
 
         # Update using the int field as a uniqueness constraint. The first two are updated while the third is created
         TestModel.objects.bulk_upsert([
-            {'int_field': 0, 'char_field': '0', 'float_field': 0},
-            {'int_field': 1, 'char_field': '1', 'float_field': 1},
-            {'int_field': 2, 'char_field': '2', 'float_field': 2},
+            TestModel(int_field=0, char_field='0', float_field=0),
+            TestModel(int_field=1, char_field='1', float_field=1),
+            TestModel(int_field=2, char_field='2', float_field=2),
         ], ['int_field'], ['float_field'])
 
         # Verify that the float field was updated for the first two models and the char field was not updated for
@@ -128,9 +128,9 @@ class BulkUpsertTest(TestCase):
 
         # Update using the int field as a uniqueness constraint. The first two are updated while the third is created
         TestModel.objects.bulk_upsert([
-            {'int_field': 0, 'char_field': '0', 'float_field': 0},
-            {'int_field': 1, 'char_field': '1', 'float_field': 1},
-            {'int_field': 2, 'char_field': '2', 'float_field': 2},
+            TestModel(int_field=0, char_field='0', float_field=0),
+            TestModel(int_field=1, char_field='1', float_field=1),
+            TestModel(int_field=2, char_field='2', float_field=2),
         ], ['int_field', 'char_field'], ['float_field'])
 
         # Verify that the float field was updated for the first two models and the char field was not updated for
@@ -152,9 +152,9 @@ class BulkUpsertTest(TestCase):
 
         # Update using the int and char field as a uniqueness constraint. All three objects are created
         TestModel.objects.bulk_upsert([
-            {'int_field': 0, 'char_field': '0', 'float_field': 0},
-            {'int_field': 1, 'char_field': '1', 'float_field': 1},
-            {'int_field': 2, 'char_field': '2', 'float_field': 2},
+            TestModel(int_field=0, char_field='0', float_field=0),
+            TestModel(int_field=1, char_field='1', float_field=1),
+            TestModel(int_field=2, char_field='2', float_field=2),
         ], ['int_field', 'char_field'], ['float_field'])
 
         # Verify that no updates occured
@@ -180,9 +180,9 @@ class BulkUpsertTest(TestCase):
 
         # Update using the int field as a uniqueness constraint on a queryset. Only one object should be updated.
         TestModel.objects.filter(int_field=0).bulk_upsert([
-            {'int_field': 0, 'char_field': '0', 'float_field': 0},
-            {'int_field': 1, 'char_field': '1', 'float_field': 1},
-            {'int_field': 2, 'char_field': '2', 'float_field': 2},
+            TestModel(int_field=0, char_field='0', float_field=0),
+            TestModel(int_field=1, char_field='1', float_field=1),
+            TestModel(int_field=2, char_field='2', float_field=2),
         ], ['int_field'], ['float_field'])
 
         # Verify that two new objecs were inserted


### PR DESCRIPTION
@jmcriffey mcriffey I made the bulk_upsert function take models instead of dictionaries to be more consistent with the other functions
