### PR TITLE
multiple database support for bulk_upsert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,5 @@ script:
   - flake8 .
   - coverage run setup.py test
   - coverage report --fail-under=100
+  - python setup.py install
   - python setup.py build_sphinx

--- a/manager_utils/manager_utils.py
+++ b/manager_utils/manager_utils.py
@@ -193,7 +193,7 @@ def bulk_upsert(queryset, model_objs, unique_fields, update_fields=None, return_
     # Apply bulk updates and creates
     if update_fields:
         bulk_update(queryset.model.objects, model_objs_to_update, update_fields)
-    queryset.model.objects.bulk_create(model_objs_to_create)
+    queryset.bulk_create(model_objs_to_create)
 
     # Optionally return the bulk upserted values
     if return_upserts:

--- a/manager_utils/manager_utils.py
+++ b/manager_utils/manager_utils.py
@@ -192,7 +192,7 @@ def bulk_upsert(queryset, model_objs, unique_fields, update_fields=None, return_
 
     # Apply bulk updates and creates
     if update_fields:
-        bulk_update(queryset.model.objects, model_objs_to_update, update_fields)
+        bulk_update(queryset, model_objs_to_update, update_fields)
     queryset.bulk_create(model_objs_to_create)
 
     # Optionally return the bulk upserted values

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 120
+ignore=E123,E133,E226,E241,E242,E402,E731
 exclude = build,docs,env,venv,*.egg,migrations
 max-complexity = 10
 


### PR DESCRIPTION
Not sure if this is the correct way to fix this, but I was attempting to use a queryset like SomeObject.objects.using('databasename') but noticed the objects would always be written to the 'default' database, not 'databasename'.