### PR TITLE
Fix django 4.0 compatibility (remove `providing_args`)

### DIFF
--- a/manager_utils/manager_utils.py
+++ b/manager_utils/manager_utils.py
@@ -11,7 +11,7 @@ from . import upsert2
 
 
 # A signal that is emitted when any bulk operation occurs
-post_bulk_operation = Signal(providing_args=['model'])
+post_bulk_operation = Signal()  # args: model
 
 
 def id_dict(queryset):


### PR DESCRIPTION
Deprecated in [3.1](https://docs.djangoproject.com/en/4.0/releases/3.1/#id2):

> The purely documentational `providing_args` argument for `Signal` is deprecated. If you rely on this argument as documentation, you can move the text to a code comment or docstring.

Removed completely in [4.0](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0):

> The `providing_args` argument for `django.dispatch.Signal` is removed.


Django 4.0's error:

```
manager_utils/manager_utils.py", line 14, in <module>
    post_bulk_operation = Signal(providing_args=['model'])
TypeError: Signal.__init__() got an unexpected keyword argument 'providing_args
```