### PR TITLE
build(project_urls): Add PyPI links to changelog and issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,12 @@ setup(
     url='http://github.com/ambitioninc/django-manager-utils/',
     author='Wes Kendall',
     author_email='opensource@ambition.com',
+    project_urls={
+        "Bug Tracker": "https://github.com/ambitioninc/django-manager-utils/issues",
+        "Changes": "https://django-manager-utils.readthedocs.io/en/latest/release_notes.html",
+        "Documentation": "https://django-manager-utils.readthedocs.io/en/latest/",
+        "Source Code": "https://github.com/ambitioninc/django-manager-utils",
+    },
     packages=find_packages(),
     classifiers=[
         'Programming Language :: Python',


### PR DESCRIPTION
This would make release notes / issues / docs easier to get to from https://pypi.python.org/pypi/django-manager-utils/

![image](https://user-images.githubusercontent.com/26336/177364466-4bb10d66-93ce-44af-a708-a4338ba5a392.png)
